### PR TITLE
Remove unnecessary dep on `pyo3-ffi`

### DIFF
--- a/pyo3/toolchains/BUILD.bazel
+++ b/pyo3/toolchains/BUILD.bazel
@@ -5,7 +5,6 @@ rust_library_group(
     name = "pyo3",
     deps = [
         "@rpyo3c//:pyo3",
-        "@rpyo3c//:pyo3-ffi",
     ],
 )
 


### PR DESCRIPTION
There is no reason to specify the additional dep.