### PR TITLE
Transition extensions to `--compilation_mode=opt` by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ This toolchain is how the rules know which version of `pyo3` to link against.
 
 <pre>
 pyo3_extension(<a href="#pyo3_extension-name">name</a>, <a href="#pyo3_extension-srcs">srcs</a>, <a href="#pyo3_extension-aliases">aliases</a>, <a href="#pyo3_extension-compile_data">compile_data</a>, <a href="#pyo3_extension-crate_features">crate_features</a>, <a href="#pyo3_extension-crate_root">crate_root</a>, <a href="#pyo3_extension-data">data</a>, <a href="#pyo3_extension-deps">deps</a>, <a href="#pyo3_extension-edition">edition</a>,
-               <a href="#pyo3_extension-imports">imports</a>, <a href="#pyo3_extension-proc_macro_deps">proc_macro_deps</a>, <a href="#pyo3_extension-rustc_env">rustc_env</a>, <a href="#pyo3_extension-rustc_env_files">rustc_env_files</a>, <a href="#pyo3_extension-rustc_flags">rustc_flags</a>, <a href="#pyo3_extension-version">version</a>, <a href="#pyo3_extension-kwargs">kwargs</a>)
+               <a href="#pyo3_extension-imports">imports</a>, <a href="#pyo3_extension-proc_macro_deps">proc_macro_deps</a>, <a href="#pyo3_extension-rustc_env">rustc_env</a>, <a href="#pyo3_extension-rustc_env_files">rustc_env_files</a>, <a href="#pyo3_extension-rustc_flags">rustc_flags</a>, <a href="#pyo3_extension-version">version</a>,
+               <a href="#pyo3_extension-compilation_mode">compilation_mode</a>, <a href="#pyo3_extension-kwargs">kwargs</a>)
 </pre>
 
 Define a PyO3 python extension module.
@@ -160,6 +161,7 @@ This target is consumed just as a `py_library` would be.
 | <a id="pyo3_extension-rustc_env_files"></a>rustc_env_files |  Files containing additional environment variables to set for rustc. For more details see [rust_shared_library][rsl].   |  `[]` |
 | <a id="pyo3_extension-rustc_flags"></a>rustc_flags |  List of compiler flags passed to `rustc`. For more details see [rust_shared_library][rsl].   |  `[]` |
 | <a id="pyo3_extension-version"></a>version |  A version to inject in the cargo environment variable. For more details see [rust_shared_library][rsl].   |  `None` |
+| <a id="pyo3_extension-compilation_mode"></a>compilation_mode |  The [compilation_mode](https://bazel.build/reference/command-line-reference#flag--compilation_mode) value to build the extension for. If set to `"current"`, the current configuration will be used.   |  `"opt"` |
 | <a id="pyo3_extension-kwargs"></a>kwargs |  Additional keyword arguments.   |  none |
 
 

--- a/pyo3/private/tests/compilation_modes/BUILD.bazel
+++ b/pyo3/private/tests/compilation_modes/BUILD.bazel
@@ -1,0 +1,57 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_python//python:defs.bzl", "py_test")
+load("//pyo3:defs.bzl", "pyo3_extension")
+
+MODES = [
+    "dbg",
+    "opt",
+    "fastbuild",
+    "current",
+]
+
+[
+    expand_template(
+        name = "string_sum_{}_src".format(mode),
+        out = "string_sum_{}.rs".format(mode),
+        substitutions = {
+            "fn string_sum_current(": "fn string_sum_{}(".format(mode),
+        },
+        template = "string_sum_current.rs",
+    )
+    for mode in MODES
+    # `current` is the actual source file.
+    if mode != "current"
+]
+
+[
+    pyo3_extension(
+        name = "string_sum_{}".format(mode),
+        srcs = ["string_sum_{}.rs".format(mode)],
+        compilation_mode = mode,
+        edition = "2021",
+    )
+    for mode in MODES
+]
+
+[
+    expand_template(
+        name = "string_sum_{}_test_src".format(mode),
+        out = "string_sum_{}_test.py".format(mode),
+        substitutions = {
+            "compilation_modes.string_sum_current": "compilation_modes.string_sum_{}".format(mode),
+        },
+        template = "string_sum_current_test.py",
+    )
+    for mode in MODES
+    # `current` is the actual source file.
+    if mode != "current"
+]
+
+[
+    py_test(
+        name = "string_sum_{}_test".format(mode),
+        srcs = ["string_sum_{}_test.py".format(mode)],
+        deps = [":string_sum_{}".format(mode)],
+    )
+    for mode in MODES
+]

--- a/pyo3/private/tests/compilation_modes/string_sum_current.rs
+++ b/pyo3/private/tests/compilation_modes/string_sum_current.rs
@@ -1,0 +1,18 @@
+//! PyO3 Examples from https://pyo3.rs/v0.22.2/#using-rust-from-python
+
+use pyo3::prelude::*;
+
+/// Formats the sum of two numbers as string.
+#[pyfunction]
+fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
+    Ok((a + b).to_string())
+}
+
+/// A Python module implemented in Rust. The name of this function must match
+/// the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
+/// import the module.
+#[pymodule]
+fn string_sum_current(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
+    Ok(())
+}

--- a/pyo3/private/tests/compilation_modes/string_sum_current_test.py
+++ b/pyo3/private/tests/compilation_modes/string_sum_current_test.py
@@ -1,0 +1,17 @@
+"""Unit tests to show simple interactions with PyO3 modules."""
+
+import unittest
+
+# isort: off
+from pyo3.private.tests.compilation_modes.string_sum_current import sum_as_string
+
+
+class StringSumTest(unittest.TestCase):
+    """Test Class."""
+
+    def test_sum_as_string(self) -> None:
+        """Simple test of rust defined functions."""
+
+        result = sum_as_string(1337, 42)
+        self.assertIsInstance(result, str)
+        self.assertEqual("1379", result)


### PR DESCRIPTION
In most cases if I'm running the Python I want the the Rust code to be as fast as possible. Transitioning to opt I think matches user expectations.