### PR TITLE
Update preferred lib extensions for windows.

### DIFF
--- a/pyo3/private/pyo3_toolchain.bzl
+++ b/pyo3/private/pyo3_toolchain.bzl
@@ -40,7 +40,7 @@ def _pyo3_toolchain_impl(ctx):
 
     implementation = PY_IMPLEMENTATIONS[py_runtime.implementation_name.lower()]
 
-    shared_exts = (".dll", ".so", ".dylib")
+    preferred_lib_exts = (".dylib", ".so", ".lib")
 
     root_lib = None
     for lib in libs:
@@ -48,7 +48,7 @@ def _pyo3_toolchain_impl(ctx):
             root_lib = lib
             continue
 
-        if lib.basename.endswith(shared_exts) and not root_lib.basename.endswith(shared_exts):
+        if lib.basename.endswith(preferred_lib_exts) and not root_lib.basename.endswith(preferred_lib_exts):
             root_lib = lib
 
     if not root_lib:


### PR DESCRIPTION
This avoids the following error on Windows:
```
error: linking with `C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14/bin/HostX64/x64/link.exe` failed: exit code 1181
    |
    = note: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14/bin/HostX64/x64/link.exe" ...
    = note: LINK : fatal error LNK1181: cannot open input file 'python3.lib'
```