### PR TITLE
Fix overriding visibility

### DIFF
--- a/pyo3/private/pyo3.bzl
+++ b/pyo3/private/pyo3.bzl
@@ -175,7 +175,7 @@ def pyo3_extension(
         **kwargs (dict): Additional keyword arguments.
     """
     tags = kwargs.pop("tags", [])
-    visibility = kwargs.pop("visibility", [])
+    visibility = kwargs.pop("visibility", None)
 
     rust_shared_library(
         name = name + "_shared",


### PR DESCRIPTION
Prevent explicitly voiding visibility for `pyo3_extension` targets.

closes https://github.com/abrisco/rules_pyo3/issues/16