### PR TITLE
Fix non-deterministic outputs

### DIFF
--- a/pyo3/private/pyo3_toolchain.bzl
+++ b/pyo3/private/pyo3_toolchain.bzl
@@ -58,7 +58,7 @@ def _pyo3_toolchain_impl(ctx):
     # modules for any target platform.
     make_variable_info = platform_common.TemplateVariableInfo({
         "PYO3_CROSS": "1",
-        "PYO3_CROSS_LIB_DIR": "$${pwd}/" + root_lib.dirname,
+        "PYO3_CROSS_LIB_DIR": root_lib.dirname,
         "PYO3_CROSS_PYTHON_IMPLEMENTATION": implementation,
         "PYO3_CROSS_PYTHON_VERSION": version,
         "PYO3_NO_PYTHON": "1",


### PR DESCRIPTION
The `pyo3-build-config.txt` file was having sandbox paths written into it. Ultimately this path would be stripped out by `cargo_build_script` when it's ultimately used to produce a rustc flag
https://github.com/PyO3/pyo3/blob/241080aeba3e97f29ac2617cd89c0e26563d6703/pyo3-ffi/build.rs#L178-L180

The resulting path would be the same from the context of a `Rustc` action so to avoid volatility in these actions, I've updated the config to use relative paths. 

Note that the relative path will be incorrect from the context of the `cargo_build_script` target as it runs from `CARGO_MANIFEST_DIR` and not the action exec root. I haven't found anything within the build script that relies on this path being real. It simply must be real for the call to `rustc`.