### PR TITLE
Move toolchains to `dev_dependency = True`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
           - os: windows-2019
     steps:
       # Checkout the code
@@ -49,7 +49,7 @@ jobs:
         if: startswith(runner.os, 'Windows')
 
   ci-buildifier:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Checkout the code
       - uses: actions/checkout@v4

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,6 +21,7 @@ use_repo(
 register_toolchains(
     "//pyo3/toolchains:toolchain",
     "//pyo3/toolchains:rust_toolchain",
+    dev_dependency = True
 )
 
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True, repo_name = "io_bazel_stardoc")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ use_repo(
 register_toolchains(
     "//pyo3/toolchains:toolchain",
     "//pyo3/toolchains:rust_toolchain",
-    dev_dependency = True
+    dev_dependency = True,
 )
 
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True, repo_name = "io_bazel_stardoc")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,6 +18,12 @@ Refer to their setup documentation for guidance:
 
 ```python
 bazel_dep(name = "rules_pyo3", version = "{SEE_RELEASES_PAGE}")
+
+# Register default toolchains or customize your own.
+register_toolchains(
+    "@rules_pyo3//pyo3/toolchains:toolchain",
+    "@rules_pyo3//pyo3/toolchains:rust_toolchain",
+)
 ```
 
 ### WORKSPACE


### PR DESCRIPTION
This should allow users to register their own toolchains. Docs have been updated to suggest registering the default toolchains `rules_pyo3` provides.