### PR TITLE
Fix abi3 using python headers

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ module(
 
 bazel_dep(name = "rules_rust", version = "0.57.1")
 bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.11")
 

--- a/pyo3/private/BUILD.bazel
+++ b/pyo3/private/BUILD.bazel
@@ -4,6 +4,7 @@ load(
     "current_pyo3_toolchain",
     "current_rust_pyo3_toolchain",
 )
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 bzl_library(
     name = "bzl_lib",
@@ -25,5 +26,12 @@ current_rust_pyo3_toolchain(
         "no-clippy",
         "no-rustfmt",
     ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "py_headers_only",
+    hdrs = ["@rules_python//python/cc:current_py_cc_headers"],
+    includes = ["@rules_python//python/cc:includes"],
     visibility = ["//visibility:public"],
 )

--- a/pyo3/private/pyo3.bzl
+++ b/pyo3/private/pyo3.bzl
@@ -198,6 +198,17 @@ def pyo3_extension(
     tags = kwargs.pop("tags", [])
     visibility = kwargs.pop("visibility", None)
 
+    # Add macOS-specific flags
+    # https://pyo3.rs/v0.24.2/building-and-distribution.html#macos
+    macos_flags = select({
+        "@rules_rust//rust/platform:aarch64-apple-darwin": ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"],
+        "@rules_rust//rust/platform:x86_64-apple-darwin": ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"],
+        "//conditions:default": [],
+    })
+
+    all_rustc_flags = rustc_flags + macos_flags
+
+
     rust_shared_library(
         name = name + "_shared",
         aliases = aliases,
@@ -208,13 +219,13 @@ def pyo3_extension(
         data = data,
         deps = [
             Label("//pyo3/private:current_rust_pyo3_toolchain"),
-            Label("@rules_python//python/cc:current_py_cc_libs"),
+            Label("//pyo3/private:py_headers_only"),
         ] + deps,
         edition = edition,
         proc_macro_deps = proc_macro_deps,
         rustc_env = rustc_env,
         rustc_env_files = rustc_env_files,
-        rustc_flags = rustc_flags,
+        rustc_flags = all_rustc_flags,
         srcs = srcs,
         tags = depset(tags + ["manual"]).to_list(),
         version = version,


### PR DESCRIPTION
Even though abi3, abi3-py311, abi3-py312 and extension-package are used as dependencies, the compiled .so (.dylib) file is not abi3 compatible (the same .so file can't be run on python 3.12, 3.13). 

By running `bazel 'build' '//pyo3/private/tests/string_sum:string_sum'` and generating `string_sum.so` we can see a link to `@rpath/libpython3.11.dylib (compatibility version 3.11.0, current version 3.11.0)` using otool on mac (ldd on linux):

```
otool -L string_sum.so
string_sum.so:
        bazel-out/darwin_arm64-opt/bin/pyo3/private/tests/string_sum/libstring_sum.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libpython3.11.dylib (compatibility version 3.11.0, current version 3.11.0)
        /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1900.178.0)
```

This is due to the usage of `@rules_python//python/cc:current_py_cc_libs`. It can be replaced with `@rules_python//python/cc:current_py_cc_headers` and removing the link to `@rpath/libpython3.11.dylib`. 

With the changes in this PR, the otool shows:

```
otool -L string_sum.so                                                                  
string_sum.so:
        bazel-out/darwin_arm64-opt/bin/pyo3/private/tests/string_sum/libstring_sum.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1900.178.0)
```

rustc flags had to be added to work on MacOS. I would be happy to refactor this to the feature flag so that abi3 would not be used automatically if not needed.
